### PR TITLE
Remove deprecated source_recorder parameter

### DIFF
--- a/config-rules.tf
+++ b/config-rules.tf
@@ -4,7 +4,6 @@ module "aws_config_rules_us_east_1" {
   source                        = "StratusGrid/config-rules/aws"
   version                       = "1.1.0"
   include_global_resource_rules = true #only include global resource on one region to prevent duplicate rules
-  source_recorder               = module.aws_config_recorder_us_east_1[0].aws_config_configuration_recorder_id
   required_tags_enabled         = true
   required_tags = {
     tag1Key = "Environment" # Yes, the actual required format is tag#Key and the required key
@@ -29,7 +28,6 @@ module "aws_config_rules_us_east_2" {
 
   source                = "StratusGrid/config-rules/aws"
   version               = "1.1.0"
-  source_recorder       = module.aws_config_recorder_us_east_2[0].aws_config_configuration_recorder_id
   required_tags_enabled = true
   required_tags = {
     tag1Key = "Environment" # Yes, the actual required format is tag#Key and the required key
@@ -49,7 +47,6 @@ module "aws_config_rules_us_west_1" {
 
   source                = "StratusGrid/config-rules/aws"
   version               = "1.1.0"
-  source_recorder       = module.aws_config_recorder_us_west_1[0].aws_config_configuration_recorder_id
   required_tags_enabled = true
   required_tags = {
     tag1Key = "Environment" # Yes, the actual required format is tag#Key and the required key
@@ -69,7 +66,6 @@ module "aws_config_rules_us_west_2" {
 
   source                = "StratusGrid/config-rules/aws"
   version               = "1.1.0"
-  source_recorder       = module.aws_config_recorder_us_west_2[0].aws_config_configuration_recorder_id
   required_tags_enabled = true
   required_tags = {
     tag1Key = "Environment" # Yes, the actual required format is tag#Key and the required key

--- a/config-rules.tf
+++ b/config-rules.tf
@@ -2,7 +2,7 @@ module "aws_config_rules_us_east_1" {
   count = var.control_tower_enabled == false ? 1 : 0
 
   source                        = "StratusGrid/config-rules/aws"
-  version                       = "1.1.0"
+  version                       = "1.2.0"
   include_global_resource_rules = true #only include global resource on one region to prevent duplicate rules
   required_tags_enabled         = true
   required_tags = {
@@ -27,7 +27,7 @@ module "aws_config_rules_us_east_2" {
   count = var.control_tower_enabled == false ? 1 : 0
 
   source                = "StratusGrid/config-rules/aws"
-  version               = "1.1.0"
+  version               = "1.2.0"
   required_tags_enabled = true
   required_tags = {
     tag1Key = "Environment" # Yes, the actual required format is tag#Key and the required key
@@ -46,7 +46,7 @@ module "aws_config_rules_us_west_1" {
   count = var.control_tower_enabled == false ? 1 : 0
 
   source                = "StratusGrid/config-rules/aws"
-  version               = "1.1.0"
+  version               = "1.2.0"
   required_tags_enabled = true
   required_tags = {
     tag1Key = "Environment" # Yes, the actual required format is tag#Key and the required key
@@ -65,7 +65,7 @@ module "aws_config_rules_us_west_2" {
   count = var.control_tower_enabled == false ? 1 : 0
 
   source                = "StratusGrid/config-rules/aws"
-  version               = "1.1.0"
+  version               = "1.2.0"
   required_tags_enabled = true
   required_tags = {
     tag1Key = "Environment" # Yes, the actual required format is tag#Key and the required key


### PR DESCRIPTION
## Change description

> The StratusGrid "config-rules" module has deprecated the use of the "source_recorder" parameter as of version 1.2.0, and the desired functionality (avoid race condition) has been implemented with a depends-on clause.  Thus, the unnecessary lines have been removed from the account starter code.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
