### PR TITLE
Add IAM role for CICD assumable by a designated Tooling account

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.2.0, 2.2.0"
   hashes = [
     "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "h1:62mVchC1L6vOo5QS9uUf52uu0emsMM+LsPQJ1BEaTms=",
     "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
     "h1:mZPzA0bba3fHD0Ht01Qu1r1x8uKHGJbKK1/CJn11vFI=",
     "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 3.63.0, >= 3.72.0, >= 4.0.0, >= 4.9.0, ~> 4.9, >= 4.20.0"
   hashes = [
     "h1:5fBXO6E4TcmbZZLVB7pHvofZiJ++aGplZVbFD1dSVa8=",
+    "h1:BdJV7bQPBSHvy23vKDr0il05BArQUIco/XbJjHjNNsI=",
     "h1:J4PCUWoWaJbNP+GadGduWIeERw/AusE5enUJY8kKmNU=",
     "h1:RW2cho76j8Agmf9x+J7HaKNZGiFqBXrD111VHVWM7Kw=",
     "zh:01afccb7e358ccff4ad800bcdea785198669f23070fba4561c65eb05f4364fc4",

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ This file contains the plugin data for TFLint to run.
 | [aws_cloudwatch_event_target.aws_backup_to_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_iam_account_password_policy.strict](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_account_password_policy) | resource |
 | [aws_iam_policy.approver_restrictions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.cicd](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.read_only_restrictions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.restricted_admin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.s3_role_assumption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -288,6 +289,7 @@ This file contains the plugin data for TFLint to run.
 | <a name="input_service_limit_email"></a> [service\_limit\_email](#input\_service\_limit\_email) | The subscription email for AWS Service Limits | `string` | n/a | yes |
 | <a name="input_source_repo"></a> [source\_repo](#input\_source\_repo) | URL of the repo which holds this code | `string` | n/a | yes |
 | <a name="input_tooling_account"></a> [tooling\_account](#input\_tooling\_account) | Indicates if the account currently being affected is the tooling account which runs CICD pipelines. | `bool` | `false` | no |
+| <a name="input_tooling_account_id"></a> [tooling\_account\_id](#input\_tooling\_account\_id) | The account number for the tooling account. Used in IAM policy/role for use by deployment pipelines. | `string` | `""` | no |
 | <a name="input_trusted_users_account_arns"></a> [trusted\_users\_account\_arns](#input\_trusted\_users\_account\_arns) | Account which users are provisioned in and should be granted access to cross account roles. Enter like arn:aws:iam::123456789012:root | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/apply-tfvars/dev.tfvars
+++ b/apply-tfvars/dev.tfvars
@@ -20,3 +20,6 @@ logging_account_id         = "213255954913"
 # Notification Variables
 service_limit_email             = "dl@example.com"
 cost_anomaly_subscription_email = "dl@example.com"
+
+# CICD Variables
+tooling_account_id = "123123123123" # Must be filled with correct value of Tooling account which will assume the CICD role

--- a/iam-cicd.tf
+++ b/iam-cicd.tf
@@ -41,7 +41,7 @@ module "iam_role_cicd" {
   role_requires_mfa = false
 
   custom_role_policy_arns = [
-    aws_iam_policy.cicd.arn
+    aws_iam_policy.cicd[0].arn
   ]
 
   tags = merge({ "Name" = "${var.name_prefix}-pipeline-role-CICD${local.name_suffix}" })

--- a/iam-cicd.tf
+++ b/iam-cicd.tf
@@ -1,0 +1,44 @@
+data "aws_iam_policy_document" "cicd" {
+  statement {
+    sid = "AllowFullAdminExceptSomeWithMFA"
+    not_actions = [
+      "logs:Delete*",
+      "cloudtrail:Delete*",
+      "cloudtrail:Stop*",
+      "cloudtrail:Update*",
+      "sts:AssumeRoleWithSAML",
+      "sts:AssumeRoleWithWebIdentity",
+      "sts:GetFederationToken",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "cicd" {
+  name        = "CICD-policy"
+  description = "Policy to grant restricted admin for the CICD role. This admin can't do some functions such as delete the CloudTrail audit trail."
+  policy      = data.aws_iam_policy_document.cicd.json
+}
+
+
+module "iam_role_cicd" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "~> 5.9"
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.tooling_account_id}:root" # The "tooling" account must be allowed to assume this role to perform actions in this account
+  ]
+
+  create_role = true
+
+  role_name         = "${var.name_prefix}-pipeline-role-CICD" #The assuming account matches it based upon name
+  role_requires_mfa = false
+
+  custom_role_policy_arns = [
+    aws_iam_policy.cicd.arn
+  ]
+
+  tags = merge({ "Name" = "${var.name_prefix}-pipeline-role-CICD${local.name_suffix}" })
+}

--- a/iam-cicd.tf
+++ b/iam-cicd.tf
@@ -17,6 +17,8 @@ data "aws_iam_policy_document" "cicd" {
 }
 
 resource "aws_iam_policy" "cicd" {
+  count = var.tooling_account_id == "" ? 0 : 1
+
   name        = "CICD-policy"
   description = "Policy to grant restricted admin for the CICD role. This admin can't do some functions such as delete the CloudTrail audit trail."
   policy      = data.aws_iam_policy_document.cicd.json
@@ -24,6 +26,8 @@ resource "aws_iam_policy" "cicd" {
 
 
 module "iam_role_cicd" {
+  count = var.tooling_account_id == "" ? 0 : 1
+
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5.9"
 

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "tooling_account" {
   type        = bool
   default     = false
 }
+
+variable "tooling_account_id" {
+  description = "The account number for the tooling account. Used in IAM policy/role for use by deployment pipelines."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Change description

> Create a designated IAM policy and role for assumption by the "Tooling" account's CICD processes/pipeline. 

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#39 ](https://github.com/StratusGrid/terraform-account-starter/issues/39) 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
