### PR TITLE
fix: expire artifacts instead of transitioning to IA

### DIFF
--- a/s3-artifacts.tf
+++ b/s3-artifacts.tf
@@ -72,12 +72,18 @@ module "accounts_artifacts_bucket" {
   # Object Retention Rule
   lifecycle_rule = [
     {
-      id      = "Object-Archiving"
+      id      = "Object-Expiration"
       enabled = true
 
-      transition = {
-        days          = 30
-        storage_class = "STANDARD_IA"
+      abort_incomplete_multipart_upload_days = 7
+
+      expiration = {
+        days = 30
+      }
+
+      noncurrent_version_expiration = {
+        newer_noncurrent_versions = 1
+        days                      = 1
       }
     }
   ]


### PR DESCRIPTION
## Change description

> Set lifecycle to expire objects after 30 days instead of transitioning them to IA Standard

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#38 ](https://github.com/StratusGrid/terraform-account-starter/issues/38)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
